### PR TITLE
Fix core number sent in v4

### DIFF
--- a/lib/fog/ovirt/requests/compute/v4/create_vm.rb
+++ b/lib/fog/ovirt/requests/compute/v4/create_vm.rb
@@ -41,6 +41,11 @@ module Fog
             attrs[:comment] ||= ""
             attrs[:quota] = attrs[:quota].present? ? client.system_service.data_centers_service.data_center_service(datacenter).quotas_service.quota_service(attrs[:quota]).get : nil
 
+            if attrs[:cores].present?
+              cpu_topology = OvirtSDK4::CpuTopology.new(:cores => attrs[:cores], :sockets => "1")
+              attrs[:cpu] = OvirtSDK4::Cpu.new(:topology => cpu_topology)
+            end
+
             # TODO: handle cloning from template
             process_vm_opts(attrs)
 


### PR DESCRIPTION
Cores was not sent correctly so ovirt always defaulted to 1 core.
This fixes the cores to be sent as part of the Cpu details.