### PR TITLE
Fixed method_missing cops pattern

### DIFF
--- a/lib/fog/ovirt/compute.rb
+++ b/lib/fog/ovirt/compute.rb
@@ -33,8 +33,9 @@ module Fog
           @client = client
         end
 
-        # rubocop:disable Style/MethodMissingSuper, Style/MissingRespondToMissing
         def method_missing(symbol, *args)
+          super unless @client.respond_to?(symbol)
+
           if block_given?
             @client.__send__(symbol, *args) do |*block_args|
               yield(*block_args)
@@ -46,10 +47,9 @@ module Fog
           raise ::Fog::Ovirt::Errors::OvirtEngineError, e
         end
 
-        def respond_to?(symbol, include_all = false)
-          @client.respond_to?(symbol, include_all)
+        def respond_to_missing?(method_name, include_private = false)
+          @client.respond_to?(symbol, include_all) || super
         end
-        # rubocop:enable Style/MethodMissingSuper, Style/MissingRespondToMissing
       end
 
       require "fog/ovirt/compute/v3"


### PR DESCRIPTION
Changed `#respond_to?` to `#respond_to_missing?`
Changed both `method_missing` and `respond_to_missing` to call to `super`, if nothing is found on the `@client`