### PR TITLE
Fixes #24808 - Fix host boolean values in update

### DIFF
--- a/lib/fog/ovirt/compute/v4.rb
+++ b/lib/fog/ovirt/compute/v4.rb
@@ -76,7 +76,7 @@ module Fog
             case value
             when OvirtSDK4::List
               value.to_a
-            when Array, Hash, DateTime
+            when Array, Hash, DateTime, TrueClass, FalseClass
               value
             when OvirtSDK4::HighAvailability
               opts[:ha] = value.enabled


### PR DESCRIPTION
Updating a Host caused the parameters - Stateless, Start in Pause Mode, Delete Protection and more to be checked.
