### PR TITLE
Fixes #24532 - Add support for setting keyboard layout

### DIFF
--- a/lib/fog/ovirt/compute/v4.rb
+++ b/lib/fog/ovirt/compute/v4.rb
@@ -95,6 +95,7 @@ module Fog
                 :address => value.address,
                 :port => value.port,
                 :secure_port => value.secure_port,
+                :keyboard_layout => value.keyboard_layout,
                 :subject => subject,
                 :monitors => value.monitors
               }


### PR DESCRIPTION
This allows us to set the VNC keyboard layout from within Foreman host creation; which, in case of VNC + non-US keyboard is mandatory IMO).