### PR TITLE
Fixes #25644 - Ticket retrieval returned ticket object instead of ticket value

### DIFF
--- a/lib/fog/ovirt/requests/compute/v4/vm_ticket.rb
+++ b/lib/fog/ovirt/requests/compute/v4/vm_ticket.rb
@@ -4,7 +4,7 @@ module Fog
       class V4
         class Real
           def vm_ticket(id, options = {})
-            client.system_service.vms_service.vm_service(id).ticket(options)
+            client.system_service.vms_service.vm_service(id).ticket(options).value
           end
         end
 


### PR DESCRIPTION
As the object is returned instead of string, the console never really gets authenticated and thus this results in a "permission denied".