### PR TITLE
Fix namespace for fog-core best practices

### DIFF
--- a/lib/fog/bin/ovirt.rb
+++ b/lib/fog/bin/ovirt.rb
@@ -1,9 +1,9 @@
-class Ovirt < Fog::Bin
+class Compute < Fog::Bin
   class << self
     def class_for(key)
       case key
       when :compute
-        Fog::Compute::Ovirt
+        Fog::Ovirt::Compute
       else
         raise ArgumentError, "Unrecognized service: #{key}"
       end
@@ -13,7 +13,7 @@ class Ovirt < Fog::Bin
       @@connections ||= Hash.new do |hash, key|
         hash[key] = case key
                     when :compute
-                      Fog::Compute.new(:provider => "Ovirt")
+                      Fog::Ovirt::Compute.new
                     else
                       raise ArgumentError, "Unrecognized service: #{key.inspect}"
                     end

--- a/lib/fog/ovirt.rb
+++ b/lib/fog/ovirt.rb
@@ -3,11 +3,9 @@ require "fog/xml"
 require "fog/json"
 
 module Fog
-  module Compute
-    autoload :Ovirt, File.expand_path("ovirt/compute", __dir__)
-  end
-
   module Ovirt
+    autoload :Compute, "fog/ovirt/compute"
+
     extend Fog::Provider
 
     module Errors

--- a/lib/fog/ovirt/compute.rb
+++ b/lib/fog/ovirt/compute.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt < Fog::Service
+  module Ovirt
+    class Compute < Fog::Service
       recognizes :api_version, :ovirt_username, :ovirt_password, :ovirt_url,
                  :ovirt_datacenter, :ovirt_ca_cert_store, :public_key
 
@@ -58,9 +58,9 @@ module Fog
 
         # rubocop:disable Style/ConditionalAssignment
         if options[:api_version] == "v4"
-          @client = Fog::Compute::Ovirt::V4.new(options)
+          @client = Fog::Ovirt::Compute::V4.new(options)
         else
-          @client = Fog::Compute::Ovirt::V3.new(options)
+          @client = Fog::Ovirt::Compute::V3.new(options)
         end
         # rubocop:enable Style/ConditionalAssignment
       end
@@ -78,11 +78,11 @@ module Fog
       class Mock
         def initialize(options = {})
           if options[:api_version] == "v4"
-            Fog::Compute::Ovirt::V4::Mock.send(:include, Fog::Compute::Ovirt::Collections)
-            @client = Fog::Compute::Ovirt::V4::Mock.new(options)
+            Fog::Ovirt::Compute::V4::Mock.send(:include, Fog::Ovirt::Compute::Collections)
+            @client = Fog::Ovirt::Compute::V4::Mock.new(options)
           else
-            Fog::Compute::Ovirt::V3::Mock.send(:include, Fog::Compute::Ovirt::Collections)
-            @client = Fog::Compute::Ovirt::V3::Mock.new(options)
+            Fog::Ovirt::Compute::V3::Mock.send(:include, Fog::Ovirt::Compute::Collections)
+            @client = Fog::Ovirt::Compute::V3::Mock.new(options)
           end
         end
 
@@ -100,11 +100,11 @@ module Fog
       class Real
         def initialize(options = {})
           if options[:api_version] == "v4"
-            Fog::Compute::Ovirt::V4::Real.send(:include, Fog::Compute::Ovirt::Collections)
-            @client = Fog::Compute::Ovirt::V4::Real.new(options)
+            Fog::Ovirt::Compute::V4::Real.send(:include, Fog::Ovirt::Compute::Collections)
+            @client = Fog::Ovirt::Compute::V4::Real.new(options)
           else
-            Fog::Compute::Ovirt::V3::Real.send(:include, Fog::Compute::Ovirt::Collections)
-            @client = Fog::Compute::Ovirt::V3::Real.new(options)
+            Fog::Ovirt::Compute::V3::Real.send(:include, Fog::Ovirt::Compute::Collections)
+            @client = Fog::Ovirt::Compute::V3::Real.new(options)
           end
         end
 

--- a/lib/fog/ovirt/compute/v3.rb
+++ b/lib/fog/ovirt/compute/v3.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3 < Fog::Service
         requires   :ovirt_username, :ovirt_password
         recognizes :ovirt_url,      :ovirt_server, :ovirt_port, :ovirt_api_path, :ovirt_datacenter,

--- a/lib/fog/ovirt/compute/v4.rb
+++ b/lib/fog/ovirt/compute/v4.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4 < Fog::Service
         requires   :ovirt_username, :ovirt_password
         recognizes :ovirt_url,      :ovirt_server, :ovirt_port, :ovirt_api_path, :ovirt_datacenter,

--- a/lib/fog/ovirt/models/compute/affinity_group.rb
+++ b/lib/fog/ovirt/models/compute/affinity_group.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class AffinityGroup < Fog::Model
         identity :id
 

--- a/lib/fog/ovirt/models/compute/affinity_groups.rb
+++ b/lib/fog/ovirt/models/compute/affinity_groups.rb
@@ -2,10 +2,10 @@ require "fog/core/collection"
 require "fog/ovirt/models/compute/affinity_group"
 
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class AffinityGroups < Fog::Collection
-        model Fog::Compute::Ovirt::AffinityGroup
+        model Fog::Ovirt::Compute::AffinityGroup
 
         def all(filters = {})
           load service.list_affinity_groups(filters)

--- a/lib/fog/ovirt/models/compute/cluster.rb
+++ b/lib/fog/ovirt/models/compute/cluster.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class Cluster < Fog::Model
         identity :id
 

--- a/lib/fog/ovirt/models/compute/clusters.rb
+++ b/lib/fog/ovirt/models/compute/clusters.rb
@@ -2,10 +2,10 @@ require "fog/core/collection"
 require "fog/ovirt/models/compute/cluster"
 
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class Clusters < Fog::Collection
-        model Fog::Compute::Ovirt::Cluster
+        model Fog::Ovirt::Compute::Cluster
 
         def all(filters = {})
           load service.list_clusters(filters)

--- a/lib/fog/ovirt/models/compute/instance_type.rb
+++ b/lib/fog/ovirt/models/compute/instance_type.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class InstanceType < Fog::Model
         identity :id
 

--- a/lib/fog/ovirt/models/compute/instance_types.rb
+++ b/lib/fog/ovirt/models/compute/instance_types.rb
@@ -2,10 +2,10 @@ require "fog/core/collection"
 require "fog/ovirt/models/compute/instance_type"
 
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class InstanceTypes < Fog::Collection
-        model Fog::Compute::Ovirt::InstanceType
+        model Fog::Ovirt::Compute::InstanceType
 
         def all(filters = {})
           load service.list_instance_types(filters)

--- a/lib/fog/ovirt/models/compute/interface.rb
+++ b/lib/fog/ovirt/models/compute/interface.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class Interface < Fog::Model
         attr_accessor :raw
         identity :id

--- a/lib/fog/ovirt/models/compute/interfaces.rb
+++ b/lib/fog/ovirt/models/compute/interfaces.rb
@@ -2,19 +2,19 @@ require "fog/core/collection"
 require "fog/ovirt/models/compute/interface"
 
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class Interfaces < Fog::Collection
-        model Fog::Compute::Ovirt::Interface
+        model Fog::Ovirt::Compute::Interface
 
         attr_accessor :vm
 
         # rubocop:disable Metrics/AbcSize
         def all(_filters = {})
           requires :vm
-          if vm.is_a? Fog::Compute::Ovirt::Server
+          if vm.is_a? Fog::Ovirt::Compute::Server
             load service.list_vm_interfaces(vm.id)
-          elsif vm.is_a? Fog::Compute::Ovirt::Template
+          elsif vm.is_a? Fog::Ovirt::Compute::Template
             load service.list_template_interfaces(vm.id)
           else
             raise ::Fog::Ovirt::Errors::OvirtError, "interfaces should have vm or template"

--- a/lib/fog/ovirt/models/compute/operating_system.rb
+++ b/lib/fog/ovirt/models/compute/operating_system.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class OperatingSystem < Fog::Model
         attr_accessor :raw
         identity :id

--- a/lib/fog/ovirt/models/compute/operating_systems.rb
+++ b/lib/fog/ovirt/models/compute/operating_systems.rb
@@ -2,10 +2,10 @@ require "fog/core/collection"
 require "fog/ovirt/models/compute/operating_system"
 
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class OperatingSystems < Fog::Collection
-        model Fog::Compute::Ovirt::OperatingSystem
+        model Fog::Ovirt::Compute::OperatingSystem
 
         def all
           load service.list_operating_systems

--- a/lib/fog/ovirt/models/compute/quota.rb
+++ b/lib/fog/ovirt/models/compute/quota.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class Quota < Fog::Model
         identity :id
 

--- a/lib/fog/ovirt/models/compute/quotas.rb
+++ b/lib/fog/ovirt/models/compute/quotas.rb
@@ -2,10 +2,10 @@ require "fog/core/collection"
 require "fog/ovirt/models/compute/quota"
 
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class Quotas < Fog::Collection
-        model Fog::Compute::Ovirt::Quota
+        model Fog::Ovirt::Compute::Quota
 
         def all(filters = {})
           load service.list_quotas(filters)

--- a/lib/fog/ovirt/models/compute/server.rb
+++ b/lib/fog/ovirt/models/compute/server.rb
@@ -1,8 +1,8 @@
 require "fog/compute/models/server"
 
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class Server < Fog::Compute::Server
         # This will be the instance uuid which is globally unique across
         # a oVirt deployment.
@@ -53,7 +53,7 @@ module Fog
         end
 
         def interfaces
-          @interfaces ||= id.nil? ? [] : Fog::Compute::Ovirt::Interfaces.new(
+          @interfaces ||= id.nil? ? [] : Fog::Ovirt::Compute::Interfaces.new(
             :service => service,
             :vm => self
           )
@@ -75,7 +75,7 @@ module Fog
         end
 
         def volumes
-          @volumes ||= id.nil? ? [] : Fog::Compute::Ovirt::Volumes.new(
+          @volumes ||= id.nil? ? [] : Fog::Ovirt::Compute::Volumes.new(
             :service => service,
             :vm => self
           )

--- a/lib/fog/ovirt/models/compute/servers.rb
+++ b/lib/fog/ovirt/models/compute/servers.rb
@@ -2,10 +2,10 @@ require "fog/core/collection"
 require "fog/ovirt/models/compute/server"
 
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class Servers < Fog::Collection
-        model Fog::Compute::Ovirt::Server
+        model Fog::Ovirt::Compute::Server
 
         def all(filters = {})
           load service.list_virtual_machines(filters)

--- a/lib/fog/ovirt/models/compute/template.rb
+++ b/lib/fog/ovirt/models/compute/template.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class Template < Fog::Model
         identity :id
 
@@ -23,14 +23,14 @@ module Fog
         attribute :version
 
         def interfaces
-          attributes[:interfaces] ||= id.nil? ? [] : Fog::Compute::Ovirt::Interfaces.new(
+          attributes[:interfaces] ||= id.nil? ? [] : Fog::Ovirt::Compute::Interfaces.new(
             :service => service,
             :vm => self
           )
         end
 
         def volumes
-          attributes[:volumes] ||= id.nil? ? [] : Fog::Compute::Ovirt::Volumes.new(
+          attributes[:volumes] ||= id.nil? ? [] : Fog::Ovirt::Compute::Volumes.new(
             :service => service,
             :vm => self
           )

--- a/lib/fog/ovirt/models/compute/templates.rb
+++ b/lib/fog/ovirt/models/compute/templates.rb
@@ -2,10 +2,10 @@ require "fog/core/collection"
 require "fog/ovirt/models/compute/template"
 
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class Templates < Fog::Collection
-        model Fog::Compute::Ovirt::Template
+        model Fog::Ovirt::Compute::Template
 
         def all(filters = {})
           load service.list_templates(filters)

--- a/lib/fog/ovirt/models/compute/volume.rb
+++ b/lib/fog/ovirt/models/compute/volume.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class Volume < Fog::Model
         attr_accessor :raw
         identity :id
@@ -19,11 +19,11 @@ module Fog
         attribute :wipe_after_delete
 
         def size_gb
-          attributes[:size_gb] ||= attributes[:size].to_i / Fog::Compute::Ovirt::DISK_SIZE_TO_GB if attributes[:size]
+          attributes[:size_gb] ||= attributes[:size].to_i / Fog::Ovirt::Compute::DISK_SIZE_TO_GB if attributes[:size]
         end
 
         def size_gb=(size)
-          attributes[:size] = size.to_i * Fog::Compute::Ovirt::DISK_SIZE_TO_GB if size
+          attributes[:size] = size.to_i * Fog::Ovirt::Compute::DISK_SIZE_TO_GB if size
         end
 
         def to_s

--- a/lib/fog/ovirt/models/compute/volumes.rb
+++ b/lib/fog/ovirt/models/compute/volumes.rb
@@ -2,18 +2,18 @@ require "fog/core/collection"
 require "fog/ovirt/models/compute/volume"
 
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class Volumes < Fog::Collection
-        model Fog::Compute::Ovirt::Volume
+        model Fog::Ovirt::Compute::Volume
 
         attr_accessor :vm
 
         # rubocop:disable Metrics/AbcSize
         def all(_filters = {})
-          if vm.is_a? Fog::Compute::Ovirt::Server
+          if vm.is_a? Fog::Ovirt::Compute::Server
             load service.list_vm_volumes(vm.id)
-          elsif vm.is_a? Fog::Compute::Ovirt::Template
+          elsif vm.is_a? Fog::Ovirt::Compute::Template
             load service.list_template_volumes(vm.id)
           else
             load service.list_volumes

--- a/lib/fog/ovirt/requests/compute/v3/activate_volume.rb
+++ b/lib/fog/ovirt/requests/compute/v3/activate_volume.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def activate_volume(id, options)

--- a/lib/fog/ovirt/requests/compute/v3/add_interface.rb
+++ b/lib/fog/ovirt/requests/compute/v3/add_interface.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def add_interface(id, options = {})

--- a/lib/fog/ovirt/requests/compute/v3/add_to_affinity_group.rb
+++ b/lib/fog/ovirt/requests/compute/v3/add_to_affinity_group.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def add_to_affinity_group(id, options = {})

--- a/lib/fog/ovirt/requests/compute/v3/add_volume.rb
+++ b/lib/fog/ovirt/requests/compute/v3/add_volume.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           DISK_SIZE_TO_GB = 1_073_741_824

--- a/lib/fog/ovirt/requests/compute/v3/attach_volume.rb
+++ b/lib/fog/ovirt/requests/compute/v3/attach_volume.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def attach_volume(id, options)

--- a/lib/fog/ovirt/requests/compute/v3/create_affinity_group.rb
+++ b/lib/fog/ovirt/requests/compute/v3/create_affinity_group.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def create_affinity_group(attrs)

--- a/lib/fog/ovirt/requests/compute/v3/create_vm.rb
+++ b/lib/fog/ovirt/requests/compute/v3/create_vm.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def create_vm(attrs)

--- a/lib/fog/ovirt/requests/compute/v3/datacenters.rb
+++ b/lib/fog/ovirt/requests/compute/v3/datacenters.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def datacenters(filter = {})

--- a/lib/fog/ovirt/requests/compute/v3/deactivate_volume.rb
+++ b/lib/fog/ovirt/requests/compute/v3/deactivate_volume.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def deactivate_volume(id, options)

--- a/lib/fog/ovirt/requests/compute/v3/destroy_affinity_group.rb
+++ b/lib/fog/ovirt/requests/compute/v3/destroy_affinity_group.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def destroy_affinity_group(id)

--- a/lib/fog/ovirt/requests/compute/v3/destroy_interface.rb
+++ b/lib/fog/ovirt/requests/compute/v3/destroy_interface.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def destroy_interface(id, options)

--- a/lib/fog/ovirt/requests/compute/v3/destroy_vm.rb
+++ b/lib/fog/ovirt/requests/compute/v3/destroy_vm.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def destroy_vm(options = {})

--- a/lib/fog/ovirt/requests/compute/v3/destroy_volume.rb
+++ b/lib/fog/ovirt/requests/compute/v3/destroy_volume.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def destroy_volume(id, options)

--- a/lib/fog/ovirt/requests/compute/v3/detach_volume.rb
+++ b/lib/fog/ovirt/requests/compute/v3/detach_volume.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def detach_volume(id, options)

--- a/lib/fog/ovirt/requests/compute/v3/get_affinity_group.rb
+++ b/lib/fog/ovirt/requests/compute/v3/get_affinity_group.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def get_affinity_group(id)

--- a/lib/fog/ovirt/requests/compute/v3/get_api_version.rb
+++ b/lib/fog/ovirt/requests/compute/v3/get_api_version.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def api_version

--- a/lib/fog/ovirt/requests/compute/v3/get_cluster.rb
+++ b/lib/fog/ovirt/requests/compute/v3/get_cluster.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def get_cluster(id)

--- a/lib/fog/ovirt/requests/compute/v3/get_instance_type.rb
+++ b/lib/fog/ovirt/requests/compute/v3/get_instance_type.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def get_instance_type(id)

--- a/lib/fog/ovirt/requests/compute/v3/get_quota.rb
+++ b/lib/fog/ovirt/requests/compute/v3/get_quota.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def get_quota(id)

--- a/lib/fog/ovirt/requests/compute/v3/get_template.rb
+++ b/lib/fog/ovirt/requests/compute/v3/get_template.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def get_template(id)

--- a/lib/fog/ovirt/requests/compute/v3/get_virtual_machine.rb
+++ b/lib/fog/ovirt/requests/compute/v3/get_virtual_machine.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def get_virtual_machine(id)

--- a/lib/fog/ovirt/requests/compute/v3/list_affinity_group_vms.rb
+++ b/lib/fog/ovirt/requests/compute/v3/list_affinity_group_vms.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def list_affinity_group_vms(id)

--- a/lib/fog/ovirt/requests/compute/v3/list_affinity_groups.rb
+++ b/lib/fog/ovirt/requests/compute/v3/list_affinity_groups.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def list_affinity_groups(filters = {})

--- a/lib/fog/ovirt/requests/compute/v3/list_clusters.rb
+++ b/lib/fog/ovirt/requests/compute/v3/list_clusters.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def list_clusters(filters = {})

--- a/lib/fog/ovirt/requests/compute/v3/list_instance_types.rb
+++ b/lib/fog/ovirt/requests/compute/v3/list_instance_types.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def list_instance_types(filters = {})

--- a/lib/fog/ovirt/requests/compute/v3/list_networks.rb
+++ b/lib/fog/ovirt/requests/compute/v3/list_networks.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def list_networks(cluster_id)

--- a/lib/fog/ovirt/requests/compute/v3/list_operating_systems.rb
+++ b/lib/fog/ovirt/requests/compute/v3/list_operating_systems.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def list_operating_systems

--- a/lib/fog/ovirt/requests/compute/v3/list_quotas.rb
+++ b/lib/fog/ovirt/requests/compute/v3/list_quotas.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def list_quotas(filters = {})

--- a/lib/fog/ovirt/requests/compute/v3/list_template_interfaces.rb
+++ b/lib/fog/ovirt/requests/compute/v3/list_template_interfaces.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def list_template_interfaces(vm_id)

--- a/lib/fog/ovirt/requests/compute/v3/list_template_volumes.rb
+++ b/lib/fog/ovirt/requests/compute/v3/list_template_volumes.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def list_template_volumes(template_id)

--- a/lib/fog/ovirt/requests/compute/v3/list_templates.rb
+++ b/lib/fog/ovirt/requests/compute/v3/list_templates.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def list_templates(filters = {})

--- a/lib/fog/ovirt/requests/compute/v3/list_virtual_machines.rb
+++ b/lib/fog/ovirt/requests/compute/v3/list_virtual_machines.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def list_virtual_machines(filters = {})

--- a/lib/fog/ovirt/requests/compute/v3/list_vm_interfaces.rb
+++ b/lib/fog/ovirt/requests/compute/v3/list_vm_interfaces.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def list_vm_interfaces(vm_id)

--- a/lib/fog/ovirt/requests/compute/v3/list_vm_volumes.rb
+++ b/lib/fog/ovirt/requests/compute/v3/list_vm_volumes.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def list_vm_volumes(vm_id)

--- a/lib/fog/ovirt/requests/compute/v3/list_volumes.rb
+++ b/lib/fog/ovirt/requests/compute/v3/list_volumes.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def list_volumes

--- a/lib/fog/ovirt/requests/compute/v3/remove_from_affinity_group.rb
+++ b/lib/fog/ovirt/requests/compute/v3/remove_from_affinity_group.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def remove_from_affinity_group(id, options = {})

--- a/lib/fog/ovirt/requests/compute/v3/storage_domains.rb
+++ b/lib/fog/ovirt/requests/compute/v3/storage_domains.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def storage_domains(filter = {})

--- a/lib/fog/ovirt/requests/compute/v3/update_interface.rb
+++ b/lib/fog/ovirt/requests/compute/v3/update_interface.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         module Shared
           def check_arguments(id, options)
@@ -10,7 +10,7 @@ module Fog
         end
 
         class Real
-          extend ::Fog::Compute::Ovirt::V3::Shared
+          extend ::Fog::Ovirt::Compute::V3::Shared
 
           def update_interface(id, options)
             check_arguments(id, options)
@@ -23,7 +23,7 @@ module Fog
         end
 
         class Mock
-          extend ::Fog::Compute::Ovirt::V3::Shared
+          extend ::Fog::Ovirt::Compute::V3::Shared
 
           def update_interface(id, options)
             check_arguments(id, options)

--- a/lib/fog/ovirt/requests/compute/v3/update_vm.rb
+++ b/lib/fog/ovirt/requests/compute/v3/update_vm.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def update_vm(attrs)

--- a/lib/fog/ovirt/requests/compute/v3/update_volume.rb
+++ b/lib/fog/ovirt/requests/compute/v3/update_volume.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         module Shared
           def check_arguments(id, options)
@@ -10,7 +10,7 @@ module Fog
         end
 
         class Real
-          extend ::Fog::Compute::Ovirt::V3::Shared
+          extend ::Fog::Ovirt::Compute::V3::Shared
 
           def update_volume(id, options)
             check_arguments(id, options)
@@ -24,7 +24,7 @@ module Fog
         end
 
         class Mock
-          extend ::Fog::Compute::Ovirt::V3::Shared
+          extend ::Fog::Ovirt::Compute::V3::Shared
 
           def update_volume(id, options)
             check_arguments(id, options)

--- a/lib/fog/ovirt/requests/compute/v3/vm_action.rb
+++ b/lib/fog/ovirt/requests/compute/v3/vm_action.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def vm_action(options = {})

--- a/lib/fog/ovirt/requests/compute/v3/vm_start_with_cloudinit.rb
+++ b/lib/fog/ovirt/requests/compute/v3/vm_start_with_cloudinit.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def vm_start_with_cloudinit(options = {})

--- a/lib/fog/ovirt/requests/compute/v3/vm_ticket.rb
+++ b/lib/fog/ovirt/requests/compute/v3/vm_ticket.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V3
         class Real
           def vm_ticket(id, options = {})

--- a/lib/fog/ovirt/requests/compute/v4/add_interface.rb
+++ b/lib/fog/ovirt/requests/compute/v4/add_interface.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           # rubocop:disable Metrics/AbcSize

--- a/lib/fog/ovirt/requests/compute/v4/add_volume.rb
+++ b/lib/fog/ovirt/requests/compute/v4/add_volume.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def add_volume(id, options = {})
@@ -20,11 +20,11 @@ module Fog
             search = options[:search] || format("datacenter=%<datacenter>s", :datacenter => datacenter)
             options[:bootable] = options.delete(:bootable)
             options[:interface] ||= OvirtSDK4::DiskInterface::VIRTIO
-            options[:provisioned_size] = options[:size_gb].to_i * Fog::Compute::Ovirt::DISK_SIZE_TO_GB if options[:size_gb]
+            options[:provisioned_size] = options[:size_gb].to_i * Fog::Ovirt::Compute::DISK_SIZE_TO_GB if options[:size_gb]
             options[:sparse] = true if options[:sparse].nil?
             options[:storage_domain_id] = options[:storage_domain] || storagedomains(:role => "data", :search => search).first.id
             # If no size is given, default to a volume size of 8GB
-            options[:provisioned_size] ||= 8 * Fog::Compute::Ovirt::DISK_SIZE_TO_GB
+            options[:provisioned_size] ||= 8 * Fog::Ovirt::Compute::DISK_SIZE_TO_GB
             options[:type] ||= OvirtSDK4::DiskType::DATA
             options[:format] ||= OvirtSDK4::DiskFormat::COW
             options[:quota] = options[:quota].present? ? client.system_service.data_centers_service.data_center_service(datacenter).quotas_service.quota_service(options[:quota]).get : nil

--- a/lib/fog/ovirt/requests/compute/v4/create_vm.rb
+++ b/lib/fog/ovirt/requests/compute/v4/create_vm.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def create_disk_attachment_from_disk(disk_to_attachment)
@@ -55,7 +55,7 @@ module Fog
               cpu_topology = OvirtSDK4::CpuTopology.new(:cores => attrs.fetch(:cores, "1"), :sockets => attrs.fetch(:sockets, "1"))
               attrs[:cpu] = OvirtSDK4::Cpu.new(:topology => cpu_topology)
             end
-            attrs[:memory_policy] = OvirtSDK4::MemoryPolicy.new(:guaranteed => attrs[:memory]) if attrs[:memory].to_i < Fog::Compute::Ovirt::DISK_SIZE_TO_GB
+            attrs[:memory_policy] = OvirtSDK4::MemoryPolicy.new(:guaranteed => attrs[:memory]) if attrs[:memory].to_i < Fog::Ovirt::Compute::DISK_SIZE_TO_GB
             attrs[:high_availability] = OvirtSDK4::HighAvailability.new(:enabled => attrs[:ha] == "1") if attrs[:ha].present?
 
             process_vm_disks(attrs) if attrs[:clone] == true && attrs[:disks].present?

--- a/lib/fog/ovirt/requests/compute/v4/datacenters.rb
+++ b/lib/fog/ovirt/requests/compute/v4/datacenters.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def datacenters(filter = {})

--- a/lib/fog/ovirt/requests/compute/v4/destroy_interface.rb
+++ b/lib/fog/ovirt/requests/compute/v4/destroy_interface.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def destroy_interface(id, options)

--- a/lib/fog/ovirt/requests/compute/v4/destroy_vm.rb
+++ b/lib/fog/ovirt/requests/compute/v4/destroy_vm.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def destroy_vm(options = {})

--- a/lib/fog/ovirt/requests/compute/v4/destroy_volume.rb
+++ b/lib/fog/ovirt/requests/compute/v4/destroy_volume.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def destroy_volume(id, options)

--- a/lib/fog/ovirt/requests/compute/v4/get_api_version.rb
+++ b/lib/fog/ovirt/requests/compute/v4/get_api_version.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def api_version

--- a/lib/fog/ovirt/requests/compute/v4/get_cluster.rb
+++ b/lib/fog/ovirt/requests/compute/v4/get_cluster.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def get_cluster(id)

--- a/lib/fog/ovirt/requests/compute/v4/get_instance_type.rb
+++ b/lib/fog/ovirt/requests/compute/v4/get_instance_type.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def get_instance_type(id)

--- a/lib/fog/ovirt/requests/compute/v4/get_quota.rb
+++ b/lib/fog/ovirt/requests/compute/v4/get_quota.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def get_quota(id)

--- a/lib/fog/ovirt/requests/compute/v4/get_template.rb
+++ b/lib/fog/ovirt/requests/compute/v4/get_template.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def get_template(id)

--- a/lib/fog/ovirt/requests/compute/v4/get_virtual_machine.rb
+++ b/lib/fog/ovirt/requests/compute/v4/get_virtual_machine.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def get_virtual_machine(id)

--- a/lib/fog/ovirt/requests/compute/v4/list_clusters.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_clusters.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def list_clusters(opts = {})

--- a/lib/fog/ovirt/requests/compute/v4/list_instance_types.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_instance_types.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def list_instance_types(filters = {})

--- a/lib/fog/ovirt/requests/compute/v4/list_networks.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_networks.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def list_networks(cluster_id)

--- a/lib/fog/ovirt/requests/compute/v4/list_operating_systems.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_operating_systems.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def list_operating_systems

--- a/lib/fog/ovirt/requests/compute/v4/list_quotas.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_quotas.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def list_quotas(filters = {})

--- a/lib/fog/ovirt/requests/compute/v4/list_template_interfaces.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_template_interfaces.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def list_template_interfaces(vm_id)

--- a/lib/fog/ovirt/requests/compute/v4/list_template_volumes.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_template_volumes.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           # rubocop:disable Metrics/AbcSize

--- a/lib/fog/ovirt/requests/compute/v4/list_templates.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_templates.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def list_templates(filters = {})

--- a/lib/fog/ovirt/requests/compute/v4/list_virtual_machines.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_virtual_machines.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def list_virtual_machines(filters = {})

--- a/lib/fog/ovirt/requests/compute/v4/list_vm_interfaces.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_vm_interfaces.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def list_vm_interfaces(vm_id)

--- a/lib/fog/ovirt/requests/compute/v4/list_vm_volumes.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_vm_volumes.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           # rubocop:disable Metrics/AbcSize

--- a/lib/fog/ovirt/requests/compute/v4/list_volumes.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_volumes.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def list_volumes

--- a/lib/fog/ovirt/requests/compute/v4/storage_domains.rb
+++ b/lib/fog/ovirt/requests/compute/v4/storage_domains.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def storage_domains(filter = {})

--- a/lib/fog/ovirt/requests/compute/v4/update_interface.rb
+++ b/lib/fog/ovirt/requests/compute/v4/update_interface.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         module Shared
           def check_arguments(id, options)
@@ -10,7 +10,7 @@ module Fog
         end
 
         class Real
-          extend ::Fog::Compute::Ovirt::V4::Shared
+          extend ::Fog::Ovirt::Compute::V4::Shared
 
           def update_interface(id, options)
             options = convert_string_to_bool(options)
@@ -23,7 +23,7 @@ module Fog
         end
 
         class Mock
-          extend ::Fog::Compute::Ovirt::V4::Shared
+          extend ::Fog::Ovirt::Compute::V4::Shared
 
           def update_interface(id, options)
             check_arguments(id, options)

--- a/lib/fog/ovirt/requests/compute/v4/update_vm.rb
+++ b/lib/fog/ovirt/requests/compute/v4/update_vm.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           # rubocop:disable Metrics/AbcSize

--- a/lib/fog/ovirt/requests/compute/v4/update_volume.rb
+++ b/lib/fog/ovirt/requests/compute/v4/update_volume.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         module Shared
           def check_arguments(id, options)
@@ -10,7 +10,7 @@ module Fog
         end
 
         class Real
-          extend ::Fog::Compute::Ovirt::V4::Shared
+          extend ::Fog::Ovirt::Compute::V4::Shared
 
           def update_volume(id, options)
             check_arguments(id, options)
@@ -23,7 +23,7 @@ module Fog
         end
 
         class Mock
-          extend ::Fog::Compute::Ovirt::V4::Shared
+          extend ::Fog::Ovirt::Compute::V4::Shared
 
           def update_volume(id, options)
             check_arguments(id, options)

--- a/lib/fog/ovirt/requests/compute/v4/vm_action.rb
+++ b/lib/fog/ovirt/requests/compute/v4/vm_action.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def vm_action(options = {})

--- a/lib/fog/ovirt/requests/compute/v4/vm_start_with_cloudinit.rb
+++ b/lib/fog/ovirt/requests/compute/v4/vm_start_with_cloudinit.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def vm_start_with_cloudinit(options = {})

--- a/lib/fog/ovirt/requests/compute/v4/vm_ticket.rb
+++ b/lib/fog/ovirt/requests/compute/v4/vm_ticket.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Compute
-    class Ovirt
+  module Ovirt
+    class Compute
       class V4
         class Real
           def vm_ticket(id, options = {})

--- a/tests/ovirt/compute_tests.rb
+++ b/tests/ovirt/compute_tests.rb
@@ -1,5 +1,5 @@
-Shindo.tests("Fog::Compute[:ovirt]", ["ovirt"]) do
-  compute = Fog::Compute[:ovirt]
+Shindo.tests("Fog::Ovirt::Compute.new", ["ovirt"]) do
+  compute = Fog::Ovirt::Compute.new
 
   tests("Compute attributes") do
     %w[ovirt_attrs].each do |attr|

--- a/tests/ovirt/models/compute/cluster_tests.rb
+++ b/tests/ovirt/models/compute/cluster_tests.rb
@@ -1,5 +1,5 @@
-Shindo.tests("Fog::Compute[:ovirt] | cluster model", ["ovirt"]) do
-  clusters = Fog::Compute[:ovirt].clusters
+Shindo.tests("Fog::Ovirt::Compute.new | cluster model", ["ovirt"]) do
+  clusters = Fog::Ovirt::Compute.new.clusters
   cluster = clusters.last
 
   tests("The cluster model should") do
@@ -23,6 +23,6 @@ Shindo.tests("Fog::Compute[:ovirt] | cluster model", ["ovirt"]) do
         end
       end
     end
-    test("be a kind of Fog::Compute::Ovirt::Cluster") { cluster.is_a? Fog::Compute::Ovirt::Cluster }
+    test("be a kind of Fog::Ovirt::Compute::Cluster") { cluster.is_a? Fog::Ovirt::Compute::Cluster }
   end
 end

--- a/tests/ovirt/models/compute/clusters_tests.rb
+++ b/tests/ovirt/models/compute/clusters_tests.rb
@@ -1,7 +1,7 @@
-Shindo.tests("Fog::Compute[:ovirt] | clusters collection", ["ovirt"]) do
-  clusters = Fog::Compute[:ovirt].clusters
+Shindo.tests("Fog::Ovirt::Compute.new | clusters collection", ["ovirt"]) do
+  clusters = Fog::Ovirt::Compute.new.clusters
 
   tests("The clusters collection") do
-    test("should be a kind of Fog::Compute::Ovirt::Clusters") { clusters.is_a? Fog::Compute::Ovirt::Clusters }
+    test("should be a kind of Fog::Ovirt::Compute::Clusters") { clusters.is_a? Fog::Ovirt::Compute::Clusters }
   end
 end

--- a/tests/ovirt/models/compute/interface_tests.rb
+++ b/tests/ovirt/models/compute/interface_tests.rb
@@ -1,5 +1,5 @@
-Shindo.tests("Fog::Compute[:ovirt] | interface model", ["ovirt"]) do
-  interfaces = Fog::Compute[:ovirt].servers.last.interfaces
+Shindo.tests("Fog::Ovirt::Compute.new | interface model", ["ovirt"]) do
+  interfaces = Fog::Ovirt::Compute.new.servers.last.interfaces
   interface = interfaces.last
 
   tests("The interface model should") do
@@ -20,6 +20,6 @@ Shindo.tests("Fog::Compute[:ovirt] | interface model", ["ovirt"]) do
         end
       end
     end
-    test("be a kind of Fog::Compute::Ovirt::Interface") { interface.is_a? Fog::Compute::Ovirt::Interface }
+    test("be a kind of Fog::Ovirt::Compute::Interface") { interface.is_a? Fog::Ovirt::Compute::Interface }
   end
 end

--- a/tests/ovirt/models/compute/interfaces_tests.rb
+++ b/tests/ovirt/models/compute/interfaces_tests.rb
@@ -1,7 +1,7 @@
-Shindo.tests("Fog::Compute[:ovirt] | interfaces collection", ["ovirt"]) do
-  interfaces = Fog::Compute[:ovirt].interfaces
+Shindo.tests("Fog::Ovirt::Compute.new | interfaces collection", ["ovirt"]) do
+  interfaces = Fog::Ovirt::Compute.new.interfaces
 
   tests("The interfaces collection") do
-    test("should be a kind of Fog::Compute::Ovirt::Interfaces") { interfaces.is_a? Fog::Compute::Ovirt::Interfaces }
+    test("should be a kind of Fog::Ovirt::Compute::Interfaces") { interfaces.is_a? Fog::Ovirt::Compute::Interfaces }
   end
 end

--- a/tests/ovirt/models/compute/operating_system_tests.rb
+++ b/tests/ovirt/models/compute/operating_system_tests.rb
@@ -1,5 +1,5 @@
-Shindo.tests("Fog::Compute[:ovirt] | operating_system model", ["ovirt"]) do
-  operating_systems = Fog::Compute[:ovirt].operating_systems
+Shindo.tests("Fog::Ovirt::Compute.new | operating_system model", ["ovirt"]) do
+  operating_systems = Fog::Ovirt::Compute.new.operating_systems
   operating_system = operating_systems.last
 
   tests("The operating_system model should") do
@@ -18,6 +18,6 @@ Shindo.tests("Fog::Compute[:ovirt] | operating_system model", ["ovirt"]) do
         end
       end
     end
-    test("be a kind of Fog::Compute::Ovirt::OperatingSystem") { operating_system.is_a? Fog::Compute::Ovirt::OperatingSystem }
+    test("be a kind of Fog::Ovirt::Compute::OperatingSystem") { operating_system.is_a? Fog::Ovirt::Compute::OperatingSystem }
   end
 end

--- a/tests/ovirt/models/compute/operating_systems_tests.rb
+++ b/tests/ovirt/models/compute/operating_systems_tests.rb
@@ -1,8 +1,8 @@
-Shindo.tests("Fog::Compute[:ovirt] | operating_systems collection", ["ovirt"]) do
-  operating_systems = Fog::Compute[:ovirt].operating_systems
+Shindo.tests("Fog::Ovirt::Compute.new | operating_systems collection", ["ovirt"]) do
+  operating_systems = Fog::Ovirt::Compute.new.operating_systems
 
   tests("The servers collection") do
     test("should not be empty") { !operating_systems.empty? }
-    test("should be a kind of Fog::Compute::Ovirt::OperatingSystems") { operating_systems.is_a? Fog::Compute::Ovirt::OperatingSystems }
+    test("should be a kind of Fog::Ovirt::Compute::OperatingSystems") { operating_systems.is_a? Fog::Ovirt::Compute::OperatingSystems }
   end
 end

--- a/tests/ovirt/models/compute/server_tests.rb
+++ b/tests/ovirt/models/compute/server_tests.rb
@@ -1,6 +1,6 @@
 # rubocop:disable Metrics/BlockLength
-Shindo.tests("Fog::Compute[:ovirt] | server model", ["ovirt"]) do
-  servers = Fog::Compute[:ovirt].servers
+Shindo.tests("Fog::Ovirt::Compute.new | server model", ["ovirt"]) do
+  servers = Fog::Ovirt::Compute.new.servers
   server = servers.last
 
   tests("The server model should") do
@@ -42,7 +42,7 @@ Shindo.tests("Fog::Compute[:ovirt] | server model", ["ovirt"]) do
         end
       end
     end
-    test("be a kind of Fog::Compute::Ovirt::Server") { server.is_a? Fog::Compute::Ovirt::Server }
+    test("be a kind of Fog::Ovirt::Compute::Server") { server.is_a? Fog::Ovirt::Compute::Server }
   end
 end
 # rubocop:enable Metrics/BlockLength

--- a/tests/ovirt/models/compute/servers_tests.rb
+++ b/tests/ovirt/models/compute/servers_tests.rb
@@ -1,9 +1,9 @@
-Shindo.tests("Fog::Compute[:ovirt] | servers collection", ["ovirt"]) do
-  servers = Fog::Compute[:ovirt].servers
+Shindo.tests("Fog::Ovirt::Compute.new | servers collection", ["ovirt"]) do
+  servers = Fog::Ovirt::Compute.new.servers
 
   tests("The servers collection") do
     test("should not be empty") { !servers.empty? }
-    test("should be a kind of Fog::Compute::Ovirt::Servers") { servers.is_a? Fog::Compute::Ovirt::Servers }
+    test("should be a kind of Fog::Ovirt::Compute::Servers") { servers.is_a? Fog::Ovirt::Compute::Servers }
     tests("should be able to reload itself").succeeds { servers.reload }
     tests("should be able to get a model") do
       tests("by instance uuid").succeeds { servers.get servers.first.id }

--- a/tests/ovirt/models/compute/template_tests.rb
+++ b/tests/ovirt/models/compute/template_tests.rb
@@ -1,5 +1,5 @@
-Shindo.tests("Fog::Compute[:ovirt] | template model", ["ovirt"]) do
-  templates = Fog::Compute[:ovirt].templates
+Shindo.tests("Fog::Ovirt::Compute.new | template model", ["ovirt"]) do
+  templates = Fog::Ovirt::Compute.new.templates
   template = templates.last
 
   tests("The template model should") do
@@ -21,6 +21,6 @@ Shindo.tests("Fog::Compute[:ovirt] | template model", ["ovirt"]) do
         end
       end
     end
-    test("be a kind of Fog::Compute::Ovirt::Template") { template.is_a? Fog::Compute::Ovirt::Template }
+    test("be a kind of Fog::Ovirt::Compute::Template") { template.is_a? Fog::Ovirt::Compute::Template }
   end
 end

--- a/tests/ovirt/models/compute/templates_tests.rb
+++ b/tests/ovirt/models/compute/templates_tests.rb
@@ -1,7 +1,7 @@
-Shindo.tests("Fog::Compute[:ovirt] | templates collection", ["ovirt"]) do
-  templates = Fog::Compute[:ovirt].templates
+Shindo.tests("Fog::Ovirt::Compute.new | templates collection", ["ovirt"]) do
+  templates = Fog::Ovirt::Compute.new.templates
 
   tests("The templates collection") do
-    test("should be a kind of Fog::Compute::Ovirt::Templates") { templates.is_a? Fog::Compute::Ovirt::Templates }
+    test("should be a kind of Fog::Ovirt::Compute::Templates") { templates.is_a? Fog::Ovirt::Compute::Templates }
   end
 end

--- a/tests/ovirt/requests/compute/v3/client_tests.rb
+++ b/tests/ovirt/requests/compute/v3/client_tests.rb
@@ -1,11 +1,11 @@
-Shindo.tests("Fog::Compute[:ovirt] | client", ["ovirt"]) do
+Shindo.tests("Fog::Ovirt::Compute.new | client", ["ovirt"]) do
   before do
     @client_mock = Object.new
     def @client_mock.foo
       raise OVIRT::OvirtException, "Test"
     end
 
-    @object_under_test = Fog::Compute::Ovirt::ExceptionWrapper.new(@client_mock)
+    @object_under_test = Fog::Ovirt::Compute::ExceptionWrapper.new(@client_mock)
   end
 
   tests("Raises the right type of exception")

--- a/tests/ovirt/requests/compute/v3/create_vm_tests.rb
+++ b/tests/ovirt/requests/compute/v3/create_vm_tests.rb
@@ -1,5 +1,5 @@
-Shindo.tests("Fog::Compute[:ovirt] | vm_create request", "ovirt") do
-  compute = Fog::Compute[:ovirt]
+Shindo.tests("Fog::Ovirt::Compute.new | vm_create request", "ovirt") do
+  compute = Fog::Ovirt::Compute.new
   name_base = Time.now.to_i
 
   tests("Create VM") do

--- a/tests/ovirt/requests/compute/v3/destroy_vm_tests.rb
+++ b/tests/ovirt/requests/compute/v3/destroy_vm_tests.rb
@@ -1,5 +1,5 @@
-Shindo.tests("Fog::Compute[:ovirt] | vm_destroy request", ["ovirt"]) do
-  compute = Fog::Compute[:ovirt]
+Shindo.tests("Fog::Ovirt::Compute | vm_destroy request", ["ovirt"]) do
+  compute = Fog::Ovirt::Compute.new
   compute.create_vm(:name => "fog-" + Time.now.to_i.to_s, :cluster_name => "Default") if compute.servers.all(:search => "fog-*").empty?
   vm_id = compute.servers.all(:search => "fog-*").last.id
 

--- a/tests/ovirt/requests/compute/v3/list_datacenters_tests.rb
+++ b/tests/ovirt/requests/compute/v3/list_datacenters_tests.rb
@@ -1,5 +1,5 @@
-Shindo.tests("Fog::Compute[:ovirt] | datacenters request", ["ovirt"]) do
-  compute = Fog::Compute[:ovirt]
+Shindo.tests("Fog::Ovirt::Compute | datacenters request", ["ovirt"]) do
+  compute = Fog::Ovirt::Compute.new
 
   tests("When listing all datacenters") do
     response = compute.datacenters

--- a/tests/ovirt/requests/compute/v3/list_quotas_tests.rb
+++ b/tests/ovirt/requests/compute/v3/list_quotas_tests.rb
@@ -1,5 +1,5 @@
-Shindo.tests("Fog::Compute[:ovirt] | quotas request", ["ovirt"]) do
-  compute = Fog::Compute[:ovirt]
+Shindo.tests("Fog::Ovirt::Compute | quotas request", ["ovirt"]) do
+  compute = Fog::Ovirt::Compute.new
 
   tests("When listing all quotas") do
     response = compute.quotas

--- a/tests/ovirt/requests/compute/v3/list_storage_domains_tests.rb
+++ b/tests/ovirt/requests/compute/v3/list_storage_domains_tests.rb
@@ -1,5 +1,5 @@
-Shindo.tests("Fog::Compute[:ovirt] | storage_domains request", ["ovirt"]) do
-  compute = Fog::Compute[:ovirt]
+Shindo.tests("Fog::Ovirt::Compute | storage_domains request", ["ovirt"]) do
+  compute = Fog::Ovirt::Compute.new
 
   tests("When listing all storage_domains") do
     response = compute.storage_domains

--- a/tests/ovirt/requests/compute/v3/update_vm_tests.rb
+++ b/tests/ovirt/requests/compute/v3/update_vm_tests.rb
@@ -1,5 +1,5 @@
-Shindo.tests("Fog::Compute[:ovirt] | vm_update request", ["ovirt"]) do
-  compute = Fog::Compute[:ovirt]
+Shindo.tests("Fog::Ovirt::Compute | vm_update request", ["ovirt"]) do
+  compute = Fog::Ovirt::Compute.new
   compute.create_vm(:name => "fog-" + Time.now.to_i.to_s, :cluster_name => "Default") if compute.servers.all(:search => "fog-*").empty?
   vm = compute.servers.all(:search => "fog-*").last
 

--- a/tests/ovirt/requests/compute/v3/update_volume_tests.rb
+++ b/tests/ovirt/requests/compute/v3/update_volume_tests.rb
@@ -1,5 +1,5 @@
-Shindo.tests("Fog::Compute[:ovirt] | update_volume request", ["ovirt"]) do
-  compute = Fog::Compute[:ovirt]
+Shindo.tests("Fog::Ovirt::Compute | update_volume request", ["ovirt"]) do
+  compute = Fog::Ovirt::Compute.new
   compute.create_vm(:name => "fog-" + Time.now.to_i.to_s, :cluster_name => "Default") if compute.servers.all(:search => "fog-*").empty?
   vm_id = compute.servers.all(:search => "fog-*").last
 

--- a/tests/ovirt/requests/compute/v4/client_tests.rb
+++ b/tests/ovirt/requests/compute/v4/client_tests.rb
@@ -1,11 +1,11 @@
-Shindo.tests("Fog::Compute[:ovirt] | client", ["ovirt"]) do
+Shindo.tests("Fog::Ovirt::Compute.new | client", ["ovirt"]) do
   before do
     @client_mock = Object.new
     def @client_mock.foo
       raise OVIRT::OvirtException, "Test"
     end
 
-    @object_under_test = Fog::Compute::Ovirt::ExceptionWrapper.new(@client_mock)
+    @object_under_test = Fog::Ovirt::Compute::ExceptionWrapper.new(@client_mock)
   end
 
   tests("Raises the right type of exception")

--- a/tests/ovirt/requests/compute/v4/create_vm_tests.rb
+++ b/tests/ovirt/requests/compute/v4/create_vm_tests.rb
@@ -1,5 +1,5 @@
-Shindo.tests("Fog::Compute[:ovirt] v4 | vm_create request", "ovirt") do
-  compute = Fog::Compute.new(:provider => :ovirt, :api_version => "v4")
+Shindo.tests("Fog::Ovirt::Compute v4 | vm_create request", "ovirt") do
+  compute = Fog::Ovirt::Compute.new(:api_version => "v4")
   name_base = Time.now.to_i
 
   tests("Create VM") do

--- a/tests/ovirt/requests/compute/v4/destroy_vm_tests.rb
+++ b/tests/ovirt/requests/compute/v4/destroy_vm_tests.rb
@@ -1,5 +1,5 @@
-Shindo.tests("Fog::Compute[:ovirt] v4 | vm_destroy request", ["ovirt"]) do
-  compute = Fog::Compute.new(:provider => :ovirt, :api_version => "v4")
+Shindo.tests("Fog::Ovirt::Compute v4 | vm_destroy request", ["ovirt"]) do
+  compute = Fog::Ovirt::Compute.new(:api_version => "v4")
   compute.create_vm(:name => "fog-" + Time.now.to_i.to_s, :cluster_name => "Default") if compute.servers.all(:search => "fog-*").empty?
   vm_id = compute.servers.all(:search => "fog-*").last.id
 

--- a/tests/ovirt/requests/compute/v4/list_datacenters_tests.rb
+++ b/tests/ovirt/requests/compute/v4/list_datacenters_tests.rb
@@ -1,4 +1,4 @@
-Shindo.tests("Fog::Compute[:ovirt] v4 | datacenters request", ["ovirt"]) do
+Shindo.tests("Fog::Ovirt::Compute.new v4 | datacenters request", ["ovirt"]) do
   compute = Fog::Compute.new(:provider => :ovirt, :api_version => "v4")
 
   tests("When listing all datacenters") do

--- a/tests/ovirt/requests/compute/v4/list_quotas_tests.rb
+++ b/tests/ovirt/requests/compute/v4/list_quotas_tests.rb
@@ -1,4 +1,4 @@
-Shindo.tests("Fog::Compute[:ovirt] v4 | quotas request", ["ovirt"]) do
+Shindo.tests("Fog::Ovirt::Compute.new v4 | quotas request", ["ovirt"]) do
   compute = Fog::Compute.new(:provider => :ovirt, :api_version => "v4")
 
   tests("When listing all quotas") do

--- a/tests/ovirt/requests/compute/v4/list_storage_domains_tests.rb
+++ b/tests/ovirt/requests/compute/v4/list_storage_domains_tests.rb
@@ -1,4 +1,4 @@
-Shindo.tests("Fog::Compute[:ovirt] v4 | storage_domains request", ["ovirt"]) do
+Shindo.tests("Fog::Ovirt::Compute.new v4 | storage_domains request", ["ovirt"]) do
   compute = Fog::Compute.new(:provider => :ovirt, :api_version => "v4")
 
   tests("When listing all storage_domains") do

--- a/tests/ovirt/requests/compute/v4/update_volume_tests.rb
+++ b/tests/ovirt/requests/compute/v4/update_volume_tests.rb
@@ -1,4 +1,4 @@
-Shindo.tests("Fog::Compute[:ovirt] v4 | update_volume request", ["ovirt"]) do
+Shindo.tests("Fog::Ovirt::Compute.new v4 | update_volume request", ["ovirt"]) do
   compute = Fog::Compute.new(:provider => :ovirt, :api_version => "v4")
   compute.create_vm(:name => "fog-" + Time.now.to_i.to_s, :cluster_name => "Default") if compute.servers.all(:search => "fog-*").empty?
   vm_id = compute.servers.all(:search => "fog-*").last


### PR DESCRIPTION
Tests pass locally with `fog-core` 2.1.2.
I still need to run tests with `fog-core` 1.45 and test with foreman.