### PR TITLE
Add vm resources max values

### DIFF
--- a/lib/fog/ovirt/compute/base.rb
+++ b/lib/fog/ovirt/compute/base.rb
@@ -1,0 +1,103 @@
+module Fog
+  module Ovirt
+    class Compute
+      class Base
+        # Max resources values for VMs depending on oVirt's version
+        # These values can be found by running the engine-config command on the engine
+        # with following config keys:
+        # - MaxNumOfVmCpus
+        # - MaxNumOfVmSockets
+        # - VM64BitMaxMemorySizeInMB
+        # - VM32BitMaxMemorySizeInMB,
+        #
+        # Eg:
+        #
+        # engine-config --get MaxNumOfVmCpus
+        # MaxNumOfVmCpus: 288 version: 4.1
+        # MaxNumOfVmCpus: 384 version: 4.2
+        # MaxNumOfVmCpus: 384 version: 4.3
+        #
+        VM_MAX_VALUES = {
+          # Default values for unknown version
+          "unknown" => { :max_num_of_vm_cpus => 240,
+                         :max_num_of_vm_sockets => 16,
+                         :vm64_bit_max_memory_size_in_mb => 4_194_304,
+                         :vm32_bit_max_memory_size_in_mb => 20_480 },
+          "3.6" => { :max_num_of_vm_cpus => 240,
+                     :max_num_of_vm_sockets => 16,
+                     :vm64_bit_max_memory_size_in_mb => 4_194_304,
+                     :vm32_bit_max_memory_size_in_mb => 20_480 },
+          "4.0" => { :max_num_of_vm_cpus => 240,
+                     :max_num_of_vm_sockets => 16,
+                     :vm64_bit_max_memory_size_in_mb => 4_194_304,
+                     :vm32_bit_max_memory_size_in_mb => 20_480 },
+          "4.1" => { :max_num_of_vm_cpus => 288,
+                     :max_num_of_vm_sockets => 16,
+                     :vm64_bit_max_memory_size_in_mb => 4_194_304,
+                     :vm32_bit_max_memory_size_in_mb => 20_480 },
+          "4.2" => { :max_num_of_vm_cpus => 384,
+                     :max_num_of_vm_sockets => 16,
+                     :vm64_bit_max_memory_size_in_mb => 4_194_304,
+                     :vm32_bit_max_memory_size_in_mb => 20_480 },
+          "4.3" => { :max_num_of_vm_cpus => 384,
+                     :max_num_of_vm_sockets => 16,
+                     :vm64_bit_max_memory_size_in_mb => 4_194_304,
+                     :vm32_bit_max_memory_size_in_mb => 20_480 }
+        }.freeze
+
+        def initialize(options = {})
+          @datacenter = options[:ovirt_datacenter]
+        end
+
+        def datacenter
+          @datacenter ||= datacenter_hash[:id]
+        end
+
+        def datacenter_hash
+          @datacenter_hash ||= datacenters.find { |x| x[:id] == @datacenter } if @datacenter
+          @datacenter_hash ||= datacenters.first
+        end
+
+        def api_version
+          raise NotImplementedError
+        end
+
+        def datacenter_version
+          "unknown"
+        end
+
+        def max_num_of_vm_cpus
+          vm_max_value(:max_num_of_vm_cpus)
+        end
+
+        def max_num_of_vm_sockets
+          vm_max_value(:max_num_of_vm_sockets)
+        end
+
+        def vm64_bit_max_memory_size_in_mb
+          vm_max_value(:vm64_bit_max_memory_size_in_mb)
+        end
+
+        def vm32_bit_max_memory_size_in_mb
+          vm_max_value(:vm32_bit_max_memory_size_in_mb)
+        end
+
+        def vm_max_memory_size_in_mb
+          vm64_bit_max_memory_size_in_mb
+        end
+
+        protected
+
+        def vm_max_value(key)
+          if VM_MAX_VALUES.key?(datacenter_version)
+            VM_MAX_VALUES[datacenter_version][key]
+          else
+            VM_MAX_VALUES["unknown"][key]
+          end
+        end
+
+        attr_reader :client
+      end
+    end
+  end
+end

--- a/lib/fog/ovirt/compute/v3.rb
+++ b/lib/fog/ovirt/compute/v3.rb
@@ -1,3 +1,5 @@
+require "fog/ovirt/compute/base"
+
 module Fog
   module Ovirt
     class Compute
@@ -99,12 +101,13 @@ module Fog
           end
         end
 
-        class Real
+        class Real < Fog::Ovirt::Compute::Base
           include Shared
 
           # rubocop:disable Metrics/AbcSize
           def initialize(options = {})
             require "rbovirt"
+            super(options)
             username   = options[:ovirt_username]
             password   = options[:ovirt_password]
             server     = options[:ovirt_server]
@@ -127,9 +130,13 @@ module Fog
             client.api_version
           end
 
-          private
-
-          attr_reader :client
+          def datacenter_version
+            if datacenter_hash && datacenter_hash[:version]
+              datacenter_hash[:version]
+            else
+              super()
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Related to https://projects.theforeman.org/issues/27086, https://github.com/theforeman/foreman/pull/6852#issuecomment-504726272

Add support of some VM resources max values (vcpus, socket, mem).

I've only oVirt 4.3 instances to test so I don't have any values for previous oVirt version, that's why there is only values for 4.1, 4.2 and 4.3 versions.