### PR TITLE
Fixes #26044 - Add VmType support for VM creation

### DIFF
--- a/lib/fog/ovirt/requests/compute/v4/create_vm.rb
+++ b/lib/fog/ovirt/requests/compute/v4/create_vm.rb
@@ -40,6 +40,8 @@ module Fog
             end
 
             vms_service = client.system_service.vms_service
+
+            attrs[:type] = attrs.fetch(:type, OvirtSDK4::VmType::SERVER)
             attrs[:instance_type] = attrs[:instance_type].present? ? client.system_service.instance_types_service.instance_type_service(attrs[:instance_type]).get : nil
 
             if attrs[:template].present?

--- a/tests/ovirt/requests/compute/v4/create_vm_tests.rb
+++ b/tests/ovirt/requests/compute/v4/create_vm_tests.rb
@@ -5,6 +5,7 @@ Shindo.tests("Fog::Ovirt::Compute v4 | vm_create request", "ovirt") do
   tests("Create VM") do
     response = compute.create_vm(:name => "fog-" + name_base.to_s, :cluster_name => "Default")
     test("should be a kind of OvirtSDK4::Vm") { response.is_a? OvirtSDK4::Vm }
+    test("should be a 'OvirtSDK4::VmType::SERVER' VM type by default") { response.type == OvirtSDK4::VmType::SERVER }
   end
 
   tests("Create VM from template (clone)") do


### PR DESCRIPTION
Also updated `.rubocop_todo.yml` because it is annoying to see tests fail for that but I can remove this commit if wanted.