### PR TITLE
Fixes #28121 - Fix convert_string_to_bool to deal with Array

### DIFF
--- a/lib/fog/ovirt/compute/v4.rb
+++ b/lib/fog/ovirt/compute/v4.rb
@@ -111,20 +111,22 @@ module Fog
           end
           # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
-          def convert_string_to_bool(opts)
-            return opts unless opts.present?
-            opts.each do |key, value|
-              if value == "true"
-                opts[key] = true
-              elsif value == "false"
-                opts[key] = false
-              elsif value.is_a? Hash
-                convert_string_to_bool(value)
-              elsif value.is_a? Array
-                value.map { |item| convert_string_to_bool(item) }
+          def convert_string_to_bool(value)
+            case value
+            when "true"
+              true
+            when "false"
+              false
+            when Array
+              value.map { |elem| convert_string_to_bool(elem) }
+            when Hash
+              value.each do |key, elem|
+                value[key] = convert_string_to_bool(elem)
               end
+              value
+            else
+              value
             end
-            opts
           end
         end
 


### PR DESCRIPTION
The PR fixes a bug in the convert_string_to_bool function. ATM the function It doesn't validate the data type of the item in value.map (when it's an array). It caused the same error. It happens when deploying a host to oVirt (from Foreman 1.23):

NoMethodError: undefined method `each' for #<Fog::Ovirt::Compute::Interface:0x007f0b76120628>
/usr/share/foreman/vendor/ruby/2.3.0/gems/fog-ovirt-1.2.1/lib/fog/ovirt/compute/v4.rb:116:in `convert_string_to_bool'
/usr/share/foreman/vendor/ruby/2.3.0/gems/fog-ovirt-1.2.1/lib/fog/ovirt/compute/v4.rb:124:in `block (2 levels) in convert_string_to_bool'
/usr/share/foreman/vendor/ruby/2.3.0/gems/fog-core-2.1.0/lib/fog/core/collection.rb:18:in `map'
/usr/share/foreman/vendor/ruby/2.3.0/gems/fog-core-2.1.0/lib/fog/core/collection.rb:18:in `map'
/usr/share/foreman/vendor/ruby/2.3.0/gems/fog-ovirt-1.2.1/lib/fog/ovirt/compute/v4.rb:124:in `block in convert_string_to_bool'
/usr/share/foreman/vendor/ruby/2.3.0/gems/fog-ovirt-1.2.1/lib/fog/ovirt/compute/v4.rb:116:in `each'
/usr/share/foreman/vendor/ruby/2.3.0/gems/fog-ovirt-1.2.1/lib/fog/ovirt/compute/v4.rb:116:in `convert_string_to_bool'
/usr/share/foreman/vendor/ruby/2.3.0/gems/fog-ovirt-1.2.1/lib/fog/ovirt/requests/compute/v4/update_vm.rb:9:in `update_vm'
/usr/share/foreman/vendor/ruby/2.3.0/gems/fog-ovirt-1.2.1/lib/fog/ovirt/models/compute/server.rb:177:in `save'
/usr/share/foreman/app/models/compute_resources/foreman/model/ovirt.rb:242:in `start_vm'