### PR TITLE
Fix ovirt tests

### DIFF
--- a/tests/ovirt/requests/compute/v4/client_tests.rb
+++ b/tests/ovirt/requests/compute/v4/client_tests.rb
@@ -2,7 +2,7 @@ Shindo.tests("Fog::Ovirt::Compute.new | client", ["ovirt"]) do
   before do
     @client_mock = Object.new
     def @client_mock.foo
-      raise OVIRT::OvirtException, "Test"
+      raise ::Fog::Ovirt::Errors::OvirtError, "Test"
     end
 
     @object_under_test = Fog::Ovirt::Compute::ExceptionWrapper.new(@client_mock)


### PR DESCRIPTION
Running: bundle exec rake test
Failed with the following output: 

export FOG_MOCK=true && bundle exec shindont tests/ovirt
  
  Fog::Ovirt::Compute.new v4 | datacenters request (ovirt) ++  
  Fog::Ovirt::Compute.new v4 | quotas request (ovirt) +  
  Fog::Ovirt::Compute v4 | vm_create request (ovirt) +++  
  Fog::Ovirt::Compute v4 | vm_destroy request (ovirt) ++  
  Fog::Ovirt::Compute.new | client (ovirt)     
    /home/mshira/git/fog-ovirt/tests/ovirt/requests/compute/v4/client_tests.rb
      Fog::Ovirt::Compute.new | client (ovirt)
    - returns true
      expected => true
      returned => false
    
    /home/mshira/git/fog-ovirt/tests/ovirt/requests/compute/v4/client_tests.rb
    - returns true
      expected => true
      returned => false
  
  Fog::Ovirt::Compute.new v4 | update_volume request (ovirt) +++  
  Fog::Ovirt::Compute.new v4 | storage_domains request (ovirt) ++  
  Fog::Ovirt::Compute | datacenters request (ovirt) ++  
  Fog::Ovirt::Compute | quotas request (ovirt) +  
  Fog::Ovirt::Compute.new | vm_create request (ovirt) ++  
  Fog::Ovirt::Compute | vm_update request (ovirt) ++  
  Fog::Ovirt::Compute | vm_destroy request (ovirt) ++  
  Fog::Ovirt::Compute.new | client (ovirt) +++  
  Fog::Ovirt::Compute | update_volume request (ovirt) +++  
  Fog::Ovirt::Compute | storage_domains request (ovirt) ++  
  Fog::Ovirt::Compute.new (ovirt) +++++++++++++++++++++++++++  
  Fog::Ovirt::Compute.new | servers collection (ovirt) ++++  
  Fog::Ovirt::Compute.new | template model (ovirt) ++++++  
  Fog::Ovirt::Compute.new | templates collection (ovirt) +  
  Fog::Ovirt::Compute.new | instance_type model (ovirt) +++++++++++  
  Fog::Ovirt::Compute.new | operating_system model (ovirt) +++++++++  
  Fog::Ovirt::Compute.new | server model (ovirt) +++++++++++++++++++++++++++++++++++  
  Fog::Ovirt::Compute.new | clusters collection (ovirt) +  
  Fog::Ovirt::Compute.new | cluster model (ovirt) +++++++  
  Fog::Ovirt::Compute.new | interface model (ovirt) ++++++++  
  Fog::Ovirt::Compute.new | interfaces collection (ovirt) +  
  Fog::Ovirt::Compute.new | instance types collection (ovirt) +  
  Fog::Ovirt::Compute.new | operating_systems collection (ovirt) ++  
  2 failed, 143 succeeded in 0.463289389 seconds
  
rake aborted!
Command failed with status (1): [export FOG_MOCK=true && bundle exec shindo