### PR TITLE
Set minimum version of ovirt-engine-sdk-ruby

### DIFF
--- a/fog-ovirt.gemspec
+++ b/fog-ovirt.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("fog-core")
   spec.add_dependency("fog-json")
   spec.add_dependency("fog-xml")
-  spec.add_dependency("ovirt-engine-sdk", ">= 4.1.3")
+  spec.add_dependency("ovirt-engine-sdk", ">= 4.3.1")
   spec.add_dependency("rbovirt", "~> 0.1.5")
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
Since the version 4.3.1 of the sdk there's a new option in the
VmService#start method (:use_initialization) that could help to create
a solution for the problem reported here

https://community.theforeman.org/t/foreman-windows-and-ovirt/19365