### PR TITLE
use_initialization in vm start 

### DIFF
--- a/lib/fog/ovirt/compute/v4.rb
+++ b/lib/fog/ovirt/compute/v4.rb
@@ -9,6 +9,7 @@ module Fog
 
         request :vm_action
         request :vm_start_with_cloudinit
+        request :vm_start_with_initialization
         request :destroy_vm
         request :create_vm
         request :update_vm

--- a/lib/fog/ovirt/models/compute/server.rb
+++ b/lib/fog/ovirt/models/compute/server.rb
@@ -123,12 +123,14 @@ module Fog
 
         def start_with_cloudinit(options = {})
           wait_for { !locked? } if options[:blocking]
-          user_data = if options[:use_custom_script]
-                        { :custom_script => options[:user_data] }
-                      else
-                        Hash[YAML.safe_load(options[:user_data]).map { |a| [a.first.to_sym, a.last] }]
-                      end
-          action_status = service.vm_start_with_cloudinit(:id => id, :user_data => user_data)
+          action_status = service.vm_start_with_cloudinit(:id => id, :user_data => fetch_user_data(options))
+          reload
+          action_status
+        end
+
+        def start_with_initialization(options = {})
+          wait_for { !locked? } if options[:blocking]
+          action_status = service.vm_start_with_initialization(:id => id, :user_data => fetch_user_data(options))
           reload
           action_status
         end
@@ -181,6 +183,14 @@ module Fog
 
         def to_s
           name
+        end
+
+        private
+
+        def fetch_user_data(options)
+          return { :custom_script => options[:user_data] } if options[:use_custom_script]
+
+          Hash[YAML.safe_load(options[:user_data]).map { |a| [a.first.to_sym, a.last] }]
         end
       end
     end

--- a/lib/fog/ovirt/requests/compute/v4/vm_start_with_initialization.rb
+++ b/lib/fog/ovirt/requests/compute/v4/vm_start_with_initialization.rb
@@ -1,0 +1,23 @@
+module Fog
+  module Ovirt
+    class Compute
+      class V4
+        class Real
+          def vm_start_with_initialization(options = {})
+            raise ArgumentError, "instance id is a required parameter" unless options.key? :id
+
+            vm_service = client.system_service.vms_service.vm_service(options[:id])
+            vm_service.start(:use_initialization => true, :vm => { :initialization => options[:user_data] })
+          end
+        end
+
+        class Mock
+          def vm_start_with_initialization(options = {})
+            raise ArgumentError, "instance id is a required parameter" unless options.key? :id
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/tests/ovirt/compute_tests.rb
+++ b/tests/ovirt/compute_tests.rb
@@ -21,4 +21,9 @@ Shindo.tests("Fog::Ovirt::Compute.new", ["ovirt"]) do
       test("it should respond to #{collection}") { compute.respond_to? collection }
     end
   end
+
+  tests("compute v4 with_initialization request") do
+    compute = Fog::Ovirt::Compute.new(:api_version => "v4")
+    test("it should respond to vm_start_with_initialization") { compute.respond_to? "vm_start_with_initialization" }
+  end
 end


### PR DESCRIPTION
Since the version 4.3.1 of the ovirt-engine-sdk-ruby is possible to start a vm passing the use_initialization param.
This can be an OS agnostic way to pass init data to the starting vm

depends on:
https://github.com/fog/fog-ovirt/pull/93