### PR TITLE
Fixes #30834 - Add support for vnic profile

### DIFF
--- a/lib/fog/ovirt/compute/v4.rb
+++ b/lib/fog/ovirt/compute/v4.rb
@@ -40,6 +40,7 @@ module Fog
         request :list_quotas
         request :get_quota
         request :list_operating_systems
+        request :list_vnic_profiles
 
         module Shared
           # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/lib/fog/ovirt/models/compute/interface.rb
+++ b/lib/fog/ovirt/models/compute/interface.rb
@@ -9,6 +9,7 @@ module Fog
         attribute :network
         attribute :interface
         attribute :mac
+        attribute :vnic_profile
 
         def to_s
           name

--- a/lib/fog/ovirt/requests/compute/v4/add_interface.rb
+++ b/lib/fog/ovirt/requests/compute/v4/add_interface.rb
@@ -9,19 +9,15 @@ module Fog
             nics_service = vm.nics_service
             options = options.dup
             options = convert_string_to_bool(options)
-            if options[:network].present?
+            if options[:network].present? && options[:vnic_profile].nil?
               network = client.system_service.networks_service.network_service(options[:network]).get
-
               profiles = client.follow_link(network.vnic_profiles)
-
               profile = profiles.detect { |x| x.name == network.name }
-
               profile ||= profiles.min_by(&:name)
-
-              options.delete(:network)
-              options[:vnic_profile] = { :id => profile.id }
+              options[:vnic_profile] = profile.id
             end
-
+            options[:vnic_profile] = { :id => options[:vnic_profile] }
+            options.delete(:network)
             interface = OvirtSDK4::Nic.new(options)
             nics_service.add(interface)
           end

--- a/lib/fog/ovirt/requests/compute/v4/list_vnic_profiles.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_vnic_profiles.rb
@@ -1,0 +1,25 @@
+module Fog
+  module Ovirt
+    class Compute
+      class V4
+        class Real
+          def list_vnic_profiles(_opts = {})
+            dc_vnics = []
+            profiles = client.system_service.vnic_profiles_service.list
+            profiles.each do |profile|
+              vnic_network = client.follow_link(profile.network)
+              dc_vnics.append(profile) if vnic_network.data_center.id == datacenter
+            end
+            dc_vnics
+          end
+        end
+        class Mock
+          def list_vnic_profiles(_filters = {})
+            xml = read_xml "vnic_profiles.xml"
+            ovirt_attrs OvirtSDK4::Reader.read(Nokogiri::XML(xml).root.to_s)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/ovirt/requests/compute/v4/mock_files/vnic_profiles.xml
+++ b/lib/fog/ovirt/requests/compute/v4/mock_files/vnic_profiles.xml
@@ -1,0 +1,42 @@
+<vnic_profiles>
+  <vnic_profile href="/ovirt-engine/api/vnicprofiles/0000000a-000a-000a-000a-000000000398" id="0000000a-000a-000a-000a-000000000398">
+    <name>ovirtmgmt</name>
+    <link href="/ovirt-engine/api/vnicprofiles/0000000a-000a-000a-000a-000000000398/permissions" rel="permissions"/>
+    <pass_through>
+      <mode>disabled</mode>
+    </pass_through>
+    <port_mirroring>false</port_mirroring>
+    <network href="/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009" id="00000000-0000-0000-0000-000000000009"/>
+    <network_filter href="/ovirt-engine/api/networkfilters/b295bf02-24b8-11ea-926f-001a4a160344" id="b295bf02-24b8-11ea-926f-001a4a160344"/>
+  </vnic_profile>
+  <vnic_profile href="/ovirt-engine/api/vnicprofiles/4e7431d7-bb74-4358-b065-7dc4a0a3f9a9" id="4e7431d7-bb74-4358-b065-7dc4a0a3f9a9">
+    <name>ovirtmgmt</name>
+    <link href="/ovirt-engine/api/vnicprofiles/4e7431d7-bb74-4358-b065-7dc4a0a3f9a9/permissions" rel="permissions"/>
+    <pass_through>
+      <mode>disabled</mode>
+    </pass_through>
+    <port_mirroring>false</port_mirroring>
+    <network href="/ovirt-engine/api/networks/f89cd192-657a-49aa-99ae-f325882eb70c" id="f89cd192-657a-49aa-99ae-f325882eb70c"/>
+    <network_filter href="/ovirt-engine/api/networkfilters/b295bf02-24b8-11ea-926f-001a4a160344" id="b295bf02-24b8-11ea-926f-001a4a160344"/>
+  </vnic_profile>
+  <vnic_profile href="/ovirt-engine/api/vnicprofiles/51249f24-17d3-48e8-807e-689d85a22b14" id="51249f24-17d3-48e8-807e-689d85a22b14">
+    <name>test</name>
+    <link href="/ovirt-engine/api/vnicprofiles/51249f24-17d3-48e8-807e-689d85a22b14/permissions" rel="permissions"/>
+    <pass_through>
+      <mode>disabled</mode>
+    </pass_through>
+    <port_mirroring>true</port_mirroring>
+    <network href="/ovirt-engine/api/networks/f89cd192-657a-49aa-99ae-f325882eb70c" id="f89cd192-657a-49aa-99ae-f325882eb70c"/>
+    <network_filter href="/ovirt-engine/api/networkfilters/b295bf02-24b8-11ea-926f-001a4a160344" id="b295bf02-24b8-11ea-926f-001a4a160344"/>
+  </vnic_profile>
+  <vnic_profile href="/ovirt-engine/api/vnicprofiles/8267104a-7597-474b-a617-9c787c1a8e9d" id="8267104a-7597-474b-a617-9c787c1a8e9d">
+    <name>fff</name>
+    <link href="/ovirt-engine/api/vnicprofiles/8267104a-7597-474b-a617-9c787c1a8e9d/permissions" rel="permissions"/>
+    <pass_through>
+      <mode>disabled</mode>
+    </pass_through>
+    <port_mirroring>false</port_mirroring>
+    <network href="/ovirt-engine/api/networks/00000000-0000-0000-0000-000000000009" id="00000000-0000-0000-0000-000000000009"/>
+    <network_filter href="/ovirt-engine/api/networkfilters/b295bf02-24b8-11ea-926f-001a4a160344" id="b295bf02-24b8-11ea-926f-001a4a160344"/>
+  </vnic_profile>
+</vnic_profiles>


### PR DESCRIPTION
VNIC profile was introduced in oVirt 3.3, 
VNICl wraps a few properties: 
Network
Quality of Service
Port mirroring
Custom properties

so. In ovirt, you can no longer create a VM with network, you have to create a VM  with vnic profile...
In ovirt, if you created a network without vnic profile, an automatically vnicprofile will be created with the same network name.