### PR TITLE
Fix open struct error

### DIFF
--- a/lib/fog/ovirt/compute/v4.rb
+++ b/lib/fog/ovirt/compute/v4.rb
@@ -1,5 +1,6 @@
 require "active_support"
 require "active_support/core_ext"
+require "ostruct"
 
 module Fog
   module Ovirt


### PR DESCRIPTION
uninitialized constant Fog::Ovirt::Compute::V4::Shared::OpenStruct (NameError)

Fog::Ovirt::Compute.new | template model (ovirt) test is failing because of this