### PR TITLE
Fix rubocop yaml config error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_from: .rubocop_todo.yml
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 100
   Enabled: false
 


### PR DESCRIPTION
.rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout