### PR TITLE
Explicitly list files and dirs included in gemspec (test_)files

### DIFF
--- a/fog-ovirt.gemspec
+++ b/fog-ovirt.gemspec
@@ -15,8 +15,9 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/fog/fog-ovirt"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.test_files    = spec.files.grep(%r{^tests\/})
+  spec.files = Dir["{lib,spec}/**/*"] +
+               ["LICENSE.md", "Rakefile", "README.md", "CHANGELOG.md", "CONTRIBUTORS.md"]
+  spec.test_files = Dir["tests/**/*"]
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.0.0"
 


### PR DESCRIPTION
With the catch all approach there were a lot of files included that do not need to be in the gem.
I.e. Jenkinsfile, all dot files and dirs related to CI configuration, and rubocop linting ...

This causes problems when i.e. building rpm packages where all of these files need to be explicitly excluded